### PR TITLE
Add basic OTruyen crawler with queue and schedule

### DIFF
--- a/truyen_tranh_app/app/Console/Commands/OTruyenCrawlCommand.php
+++ b/truyen_tranh_app/app/Console/Commands/OTruyenCrawlCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\CrawlOTruyenNovel;
+use App\Services\OTruyenService;
+use Illuminate\Console\Command;
+
+class OTruyenCrawlCommand extends Command
+{
+    protected $signature = 'otruyen:crawl {--page=1 : Page to crawl}';
+
+    protected $description = 'Fetch novel list from OTruyen API and dispatch crawl jobs';
+
+    public function handle(OTruyenService $service): int
+    {
+        $page = (int) $this->option('page');
+        $novels = $service->fetchLatestNovels($page);
+
+        foreach ($novels as $novel) {
+            if (!empty($novel['slug'])) {
+                CrawlOTruyenNovel::dispatch($novel['slug']);
+            }
+        }
+
+        $this->info('Dispatched crawl jobs for '.count($novels).' novels.');
+
+        return 0;
+    }
+}
+

--- a/truyen_tranh_app/app/Console/Kernel.php
+++ b/truyen_tranh_app/app/Console/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('otruyen:crawl')->hourly();
     }
 
     /**

--- a/truyen_tranh_app/app/Jobs/CrawlOTruyenNovel.php
+++ b/truyen_tranh_app/app/Jobs/CrawlOTruyenNovel.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Category;
+use App\Models\Novel;
+use App\Services\OTruyenService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+
+class CrawlOTruyenNovel implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $slug;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(string $slug)
+    {
+        $this->slug = $slug;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(OTruyenService $service): void
+    {
+        $data = $service->fetchNovel($this->slug);
+
+        if (!$data) {
+            return;
+        }
+
+        $categoryName = $data['category'] ?? 'Uncategorized';
+        $category = Category::firstOrCreate(
+            ['slug' => Str::slug($categoryName)],
+            ['name' => $categoryName]
+        );
+
+        Novel::updateOrCreate(
+            ['title' => $data['title'] ?? $this->slug],
+            [
+                'description' => $data['content'] ?? null,
+                'cover_image' => $data['thumb_url'] ?? null,
+                'author_id' => 1,
+                'category_id' => $category->id,
+                'status' => $data['status'] ?? 'ongoing',
+            ]
+        );
+    }
+}
+

--- a/truyen_tranh_app/app/Services/OTruyenService.php
+++ b/truyen_tranh_app/app/Services/OTruyenService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class OTruyenService
+{
+    protected string $baseUrl;
+
+    public function __construct()
+    {
+        $this->baseUrl = rtrim(config('otruyen.base_url'), '/');
+    }
+
+    /**
+     * Fetch latest novels from OTruyen.
+     *
+     * @param int $page
+     * @return array
+     */
+    public function fetchLatestNovels(int $page = 1): array
+    {
+        $response = Http::get("{$this->baseUrl}/danh-sach/truyen-moi", [
+            'page' => $page,
+        ]);
+
+        if ($response->failed()) {
+            return [];
+        }
+
+        return $response->json('data') ?? [];
+    }
+
+    /**
+     * Fetch novel detail by slug.
+     *
+     * @param string $slug
+     * @return array|null
+     */
+    public function fetchNovel(string $slug): ?array
+    {
+        $response = Http::get("{$this->baseUrl}/truyen-tranh/{$slug}");
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        return $response->json('data');
+    }
+}
+

--- a/truyen_tranh_app/config/otruyen.php
+++ b/truyen_tranh_app/config/otruyen.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'base_url' => env('OTRUYEN_API_BASE', 'https://otruyenapi.com/v1/api'),
+];
+

--- a/truyen_tranh_app/routes/web.php
+++ b/truyen_tranh_app/routes/web.php
@@ -75,3 +75,7 @@ Route::get('/profile', [PageController::class, 'profile'])->name('profile');
 Route::get('/ranking', [PageController::class, 'ranking'])->name('ranking');
 Route::get('/search', [PageController::class, 'search'])->name('search');
 Route::get('/test-cowl', [PageController::class, 'testCowl'])->name('test-cowl');
+
+Route::get('/crawler/novels', function () {
+    return \App\Models\Novel::select('title', 'status')->get();
+});


### PR DESCRIPTION
## Summary
- add OTruyen API config and service
- implement queued job and command to crawl novels
- schedule crawler and expose route to list crawled novels

## Testing
- `composer install` *(fails: GitHub token required)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a746e5713483299b896b130d96e0d4